### PR TITLE
Harmony.HarmonyInstance.Patch not found. - fix

### DIFF
--- a/RealEstate/Overrides/SimulateBarricadeOverride.cs
+++ b/RealEstate/Overrides/SimulateBarricadeOverride.cs
@@ -1,4 +1,5 @@
 ﻿using ExtraConcentratedJuice.RealEstate.Entities;
+using Harmony;
 using Rocket.API;
 using Rocket.Unturned.Chat;
 using Rocket.Unturned.Player;
@@ -12,8 +13,10 @@ using UnityEngine;
 
 namespace ExtraConcentratedJuice.RealEstate.Overrides
 {
+    [HarmonyPatch(typeof(UseableBarricade), "simulate")]
     internal class SimulateBarricadeOverride
     {
+        [HarmonyPrefix]
         internal static bool Prefix(UseableBarricade __instance, uint simulation, bool inputSteady)
         {
             UnturnedPlayer player = UnturnedPlayer.FromPlayer(__instance.player);
@@ -45,8 +48,6 @@ namespace ExtraConcentratedJuice.RealEstate.Overrides
 
             return true;
         }
-
-        internal static void PostFix() { /* lol */ }
 
         private static T GetValue<T>(UseableBarricade instance, string name, BindingFlags flags) 
             => (T)typeof(UseableBarricade).GetField(name, flags).GetValue(instance);

--- a/RealEstate/Overrides/SimulateStructureOverride.cs
+++ b/RealEstate/Overrides/SimulateStructureOverride.cs
@@ -1,4 +1,5 @@
 ﻿using ExtraConcentratedJuice.RealEstate.Entities;
+using Harmony;
 using Rocket.API;
 using Rocket.Unturned.Chat;
 using Rocket.Unturned.Player;
@@ -8,8 +9,10 @@ using UnityEngine;
 
 namespace ExtraConcentratedJuice.RealEstate.Overrides
 {
+    [HarmonyPatch(typeof(UseableStructure), "simulate")]
     internal class SimulateStructureOverride
     {
+        [HarmonyPrefix]
         internal static bool Prefix(UseableStructure __instance, uint simulation, bool inputSteady)
         {
             UnturnedPlayer player = UnturnedPlayer.FromPlayer(__instance.player);
@@ -38,12 +41,6 @@ namespace ExtraConcentratedJuice.RealEstate.Overrides
 
             return true;
         }
-
-        internal static void PostFix()
-        {
-            // lol
-        }
-
         private static T GetValue<T>(UseableStructure instance, string name, BindingFlags flags) 
             => (T)typeof(UseableStructure).GetField(name, flags).GetValue(instance);
     }

--- a/RealEstate/RealEstate.cs
+++ b/RealEstate/RealEstate.cs
@@ -41,17 +41,7 @@ namespace ExtraConcentratedJuice.RealEstate
 
             HarmonyInstance harmony = HarmonyInstance.Create("pw.cirno.extraconcentratedjuice");
 
-            var orig = typeof(UseableStructure).GetMethod("simulate", BindingFlags.Instance | BindingFlags.Public);
-            var pre = typeof(SimulateStructureOverride).GetMethod("Prefix", BindingFlags.Static | BindingFlags.NonPublic);
-            var post = typeof(SimulateStructureOverride).GetMethod("Postfix", BindingFlags.Static | BindingFlags.NonPublic);
-
-            harmony.Patch(orig, new HarmonyMethod(pre), new HarmonyMethod(post));
-
-            var orig2 = typeof(UseableBarricade).GetMethod("simulate", BindingFlags.Instance | BindingFlags.Public);
-            var pre2 = typeof(SimulateBarricadeOverride).GetMethod("Prefix", BindingFlags.Static | BindingFlags.NonPublic);
-            var post2 = typeof(SimulateBarricadeOverride).GetMethod("Postfix", BindingFlags.Static | BindingFlags.NonPublic);
-
-            harmony.Patch(orig2, new HarmonyMethod(pre2), new HarmonyMethod(post2));
+            harmony.PatchAll(Assembly);
         }
 
         protected override void Unload()


### PR DESCRIPTION
Fixed ```Failed to load RealEstate, unloading now... :System.MissingMethodException: Method 'Harmony.HarmonyInstance.Patch' not found.``` by using other way to register harmony patches. I just use attributes and PatchAll method on harmony instance.